### PR TITLE
fix: resolve password reset email link authentication flow

### DIFF
--- a/bike-parking-app/app/auth/callback/route.ts
+++ b/bike-parking-app/app/auth/callback/route.ts
@@ -28,13 +28,22 @@ export async function GET(request: Request) {
   // https://supabase.com/docs/guides/auth/server-side/nextjs
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get("code");
+  const redirectTo = requestUrl.searchParams.get("redirect_to");
   const origin = requestUrl.origin;
 
   if (code) {
     const supabase = createSupabaseServerClient();
-    await supabase.auth.exchangeCodeForSession(code);
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    
+    if (error) {
+      console.error("Error exchanging code for session:", error);
+      // Redirect to error page or login page if code exchange fails
+      return NextResponse.redirect(`${origin}/forgot-password?error=invalid_link`);
+    }
   }
 
-  // URL to redirect to after sign up process completes
-  return NextResponse.redirect(`${origin}/map`);
+  // If there's a redirect_to parameter (e.g., for password reset), use it
+  // Otherwise, redirect to the default map page
+  const redirectUrl = redirectTo ? `${origin}${redirectTo}` : `${origin}/map`;
+  return NextResponse.redirect(redirectUrl);
 }

--- a/bike-parking-app/components/auth/ForgotPasswordModal.tsx
+++ b/bike-parking-app/components/auth/ForgotPasswordModal.tsx
@@ -3,7 +3,7 @@ import { createSupabaseBrowserClient } from "@/utils/supabase/browser-client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { z } from "zod";
 import { Spinner } from "../svgs";
@@ -23,6 +23,19 @@ export default function ForgotPasswordModal() {
     defaultValues: { email: "" },
   });
 
+  useEffect(() => {
+    // Check for error parameter in URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const error = urlParams.get('error');
+    
+    if (error === 'invalid_link') {
+      toast.error('The reset link is invalid or has expired. Please request a new one.', {
+        duration: 10000,
+        id: 'invalidLink'
+      });
+    }
+  }, []);
+
   const onSubmit: SubmitHandler<z.infer<typeof EmailSchema>> = async (
     values
   ) => {
@@ -31,7 +44,7 @@ export default function ForgotPasswordModal() {
       const { data, error } = await supabase.auth.resetPasswordForEmail(
         values.email,
         {
-          redirectTo: `${window.location.href}reset-password`,
+          redirectTo: `${window.location.origin}/auth/callback?redirect_to=/reset-password`,
         }
       );
       toast.success(

--- a/bike-parking-app/components/auth/ResetPasswordModal.tsx
+++ b/bike-parking-app/components/auth/ResetPasswordModal.tsx
@@ -26,10 +26,25 @@ export default function ResetPasswordModal() {
   const supabase = createSupabaseBrowserClient();
 
   const [loading, setLoading] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const form = useForm<z.infer<typeof PasswordSchema>>({
     resolver: zodResolver(PasswordSchema),
     defaultValues: { password: "" },
   });
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      setIsAuthenticated(!!session);
+      
+      if (!session) {
+        toast.error("You need to click the reset link from your email first.");
+        router.push("/forgot-password");
+      }
+    };
+
+    checkAuth();
+  }, [supabase, router]);
 
   const onSubmit: SubmitHandler<z.infer<typeof PasswordSchema>> = async (
     values
@@ -39,20 +54,56 @@ export default function ResetPasswordModal() {
       const { data, error } = await supabase.auth.updateUser({
         password: values.password,
       });
+      
+      if (error) {
+        toast.error(`Error updating password: ${error.message}`, { 
+          id: "updateUserError",
+          duration: 10000 
+        });
+        setLoading(false);
+        return;
+      }
+
       if (data) {
         toast.success("Password successfully reset!", {
           duration: 10000,
           id: "updateUserSuccessful",
         });
+        
+        // Sign out the user to force them to log in with new password
+        await supabase.auth.signOut();
         router.push("/login");
         router.refresh();
       }
       setLoading(false);
     } catch (error) {
       setLoading(false);
-      toast.error(`Error ${error}`, { id: "updateUserError" });
+      toast.error(`Unexpected error: ${error}`, { 
+        id: "updateUserUnexpectedError",
+        duration: 10000 
+      });
     }
   };
+
+  // Show loading while checking authentication
+  if (isAuthenticated === null) {
+    return (
+      <>
+        <Toaster position="top-right" />
+        <div className="w-full max-w-sm">
+          <div className="bg-white shadow-md rounded px-8 py-6 text-center">
+            <Spinner className="animate-spin h-8 mx-auto mb-4" />
+            <p>Verifying your reset link...</p>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  // Don't render the form if not authenticated (will redirect)
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
     <>

--- a/bike-parking-app/middleware.ts
+++ b/bike-parking-app/middleware.ts
@@ -8,6 +8,11 @@ export async function middleware(request: NextRequest) {
     },
   });
 
+  // Always allow access to auth callback route
+  if (request.nextUrl.pathname === "/auth/callback") {
+    return response;
+  }
+
   const supabase = createSupabaseReqResClient(request, response);
 
   const {
@@ -44,34 +49,9 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL("/", request.url));
   }
 
-  // If user is not signed in and the current path is '/reset-password'
-  if (!user && request.nextUrl.pathname === "/reset-password") {
-    // Check if the request contains the 'token' query parameter
-    if (request.nextUrl.searchParams.has("token")) {
-      const tokenHash = request.nextUrl.searchParams.get("token");
-
-      if (tokenHash) {
-        // Verify the token hash using Supabase's verifyOtp method with type 'recovery'
-        const { data: verificationData, error } = await supabase.auth.verifyOtp({
-          token_hash: tokenHash,
-          type: "recovery",
-        });
-
-        if (error || !verificationData) {
-          // if token hash is invalid or expired, redirect unauthenticated users to '/'
-          return NextResponse.redirect(new URL("/", request.url));
-        }
-
-        return response; // Allow access to the reset password page when the token hash is valid
-      } else {
-        // Redirect unauthenticated users to '/' if tokenHash is null
-        return NextResponse.redirect(new URL("/", request.url));
-      }
-    } else {
-      // Redirect unauthenticated users to '/'
-      return NextResponse.redirect(new URL("/", request.url));
-    }
-  }
+  // Allow access to reset-password page - authentication will be checked in the component
+  // This is needed because the session might not be immediately available in middleware
+  // after the auth callback redirect
 
   return response;
 }
@@ -86,5 +66,6 @@ export const config = {
     "/register",
     "/reset-password",
     "/admin",
+    "/auth/callback",
   ],
 };


### PR DESCRIPTION
Fixes password reset functionality where email links were failing to redirect to reset-password page due to improper token verification in middleware.
- Update auth callback to handle redirect_to parameter and error handling
- Fix middleware to allow auth callback route and remove problematic token verification
- Enhance ForgotPasswordModal with proper redirect URL and error handling
- Add authentication verification to ResetPasswordModal with loading states
- Improve error handling throughout password reset flow
- Fix "One-time token not found" error by using proper Supabase auth flow token verification in middleware.